### PR TITLE
Implement basic FHIR to OMOP ETL utilities

### DIFF
--- a/fhiromop/__init__.py
+++ b/fhiromop/__init__.py
@@ -1,0 +1,3 @@
+"""Top level package for FHIR to OMOP ETL examples."""
+
+__all__ = ["parser", "mapper", "loader", "config", "qc"]

--- a/fhiromop/config.py
+++ b/fhiromop/config.py
@@ -1,0 +1,65 @@
+"""Configuration helpers for mapping FHIR resources to OMOP tables."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+__all__ = ["FieldMapping", "MappingConfig", "load_mapping"]
+
+
+@dataclass
+class FieldMapping:
+    """Configuration for a single OMOP field."""
+
+    source: str | None = None
+    """Name of the source column in the flattened FHIR DataFrame."""
+
+    transform: str | None = None
+    """Optional transformation applied to the source column (``year``,
+    ``month`` or ``day`` for date columns)."""
+
+    concept_map: Dict[str, int] | None = None
+    """Optional mapping from source string values to OMOP concept identifiers."""
+
+    default: Any | None = None
+    """Default value used when no source column is provided."""
+
+
+@dataclass
+class MappingConfig:
+    """Container for mapping configuration."""
+
+    fields: Dict[str, FieldMapping]
+
+
+def load_mapping(path: str | Path) -> MappingConfig:
+    """Load mapping configuration from a YAML file.
+
+    The YAML file must define a mapping where keys correspond to target OMOP
+    fields and values describe how those fields are constructed.  Minimal
+    validation is performed to ensure each field mapping contains either a
+    ``source`` or ``default`` attribute.
+    """
+    with open(path, "r", encoding="utf8") as f:
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("Mapping config must be a mapping")
+
+    fields: Dict[str, FieldMapping] = {}
+    for target, cfg in raw.items():
+        if not isinstance(cfg, dict):
+            raise ValueError(f"Configuration for '{target}' must be a mapping")
+        if "source" not in cfg and "default" not in cfg:
+            raise ValueError(
+                f"Configuration for '{target}' must have 'source' or 'default'"
+            )
+        fields[target] = FieldMapping(
+            source=cfg.get("source"),
+            transform=cfg.get("transform"),
+            concept_map=cfg.get("concept_map"),
+            default=cfg.get("default"),
+        )
+    return MappingConfig(fields=fields)

--- a/fhiromop/loader.py
+++ b/fhiromop/loader.py
@@ -1,0 +1,17 @@
+"""Functions for writing OMOP formatted data."""
+from __future__ import annotations
+
+from pyspark.sql import DataFrame
+
+__all__ = ["save_person"]
+
+
+def save_person(df: DataFrame, path: str) -> None:
+    """Save a PERSON table DataFrame to a CSV file.
+
+    The implementation collects the data on the driver node and writes a single
+    CSV file.  This is sufficient for demonstration purposes and small sample
+    data sets.  In a production ETL one would typically write directly using
+    Spark's distributed ``DataFrameWriter``.
+    """
+    df.toPandas().to_csv(path, index=False)

--- a/fhiromop/mapper.py
+++ b/fhiromop/mapper.py
@@ -1,0 +1,59 @@
+"""Mapping logic to transform flattened FHIR data to OMOP tables."""
+from __future__ import annotations
+
+from typing import List
+
+from pyspark.sql import DataFrame, functions as F
+
+from .config import FieldMapping, MappingConfig
+
+__all__ = ["map_person"]
+
+
+def _apply_field(df: DataFrame, mapping: FieldMapping) -> F.Column:
+    """Build a Spark column expression for a single field mapping."""
+    if mapping.source is not None:
+        col = F.col(mapping.source)
+        if mapping.transform == "year":
+            col = F.year(F.to_date(col))
+        elif mapping.transform == "month":
+            col = F.month(F.to_date(col))
+        elif mapping.transform == "day":
+            col = F.dayofmonth(F.to_date(col))
+        if mapping.concept_map:
+            from itertools import chain
+
+            mapping_expr = F.create_map(
+                list(
+                    chain(*[(F.lit(k), F.lit(v)) for k, v in mapping.concept_map.items()])
+                )
+            )
+            col = mapping_expr.getItem(col)
+    elif mapping.default is not None:
+        col = F.lit(mapping.default)
+    else:
+        col = F.lit(None)
+    return col
+
+
+def map_person(df: DataFrame, config: MappingConfig) -> DataFrame:
+    """Map flattened FHIR Patient DataFrame into OMOP PERSON format.
+
+    Parameters
+    ----------
+    df:
+        Flattened FHIR Patient DataFrame (output of
+        :func:`fhiromop.parser.read_patient_ndjson`).
+    config:
+        Mapping configuration loaded via :func:`fhiromop.config.load_mapping`.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame containing columns defined in the mapping configuration in the
+        order specified.
+    """
+    cols: List[F.Column] = []
+    for target, field_cfg in config.fields.items():
+        cols.append(_apply_field(df, field_cfg).alias(target))
+    return df.select(*cols)

--- a/fhiromop/parser.py
+++ b/fhiromop/parser.py
@@ -1,0 +1,89 @@
+"""Utility functions for reading and flattening FHIR NDJSON files.
+
+This module contains helpers to load FHIR resources exported by Synthea in
+NDJSON (newline delimited JSON) format and recursively flatten nested
+structures into a flat :class:`pyspark.sql.DataFrame`.
+
+Only a very small subset of the FHIR specification is supported and the
+flattening logic is intentionally simple.  The goal is to provide an easy to
+understand example that can be extended for additional resources.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+__all__ = ["read_patient_ndjson", "flatten"]
+
+
+def read_patient_ndjson(spark: SparkSession, path: str) -> DataFrame:
+    """Read a Synthea FHIR Patient NDJSON file and return a flat DataFrame.
+
+    Parameters
+    ----------
+    spark:
+        Active :class:`~pyspark.sql.SparkSession`.
+    path:
+        Path to the NDJSON file containing Patient resources.
+
+    Returns
+    -------
+    DataFrame
+        A DataFrame where nested structures have been flattened into top level
+        columns using ``_`` as a separator.
+    """
+    df = spark.read.json(path)
+    return flatten(df)
+
+
+def flatten(df: DataFrame) -> DataFrame:
+    """Recursively flatten a DataFrame with nested structures.
+
+    The algorithm iteratively expands ``StructType`` columns into individual
+    columns and explodes arrays of structs.  Arrays of primitive values are
+    converted to comma separated strings.  The function stops once no complex
+    fields remain.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame possibly containing nested columns.
+
+    Returns
+    -------
+    DataFrame
+        A flattened DataFrame with no ``StructType`` or ``ArrayType`` columns.
+    """
+    complex_fields: List[tuple[str, T.DataType]] = [
+        (field.name, field.dataType)
+        for field in df.schema.fields
+        if isinstance(field.dataType, (T.ArrayType, T.StructType))
+    ]
+
+    while complex_fields:
+        col_name, data_type = complex_fields.pop(0)
+        if isinstance(data_type, T.StructType):
+            # Expand struct by adding each field as a top level column
+            expanded = [
+                F.col(f"{col_name}.{name}").alias(f"{col_name}_{name}")
+                for name in data_type.names
+            ]
+            df = df.select("*", *expanded).drop(col_name)
+        elif isinstance(data_type, T.ArrayType):
+            if isinstance(data_type.elementType, T.StructType):
+                # Explode array of structs and continue flattening
+                df = df.withColumn(col_name, F.explode_outer(col_name))
+            else:
+                # Array of primitives -> comma separated string
+                df = df.withColumn(
+                    col_name, F.concat_ws(",", col_name)
+                )
+        complex_fields = [
+            (field.name, field.dataType)
+            for field in df.schema.fields
+            if isinstance(field.dataType, (T.ArrayType, T.StructType))
+        ]
+    return df

--- a/fhiromop/qc.py
+++ b/fhiromop/qc.py
@@ -1,0 +1,46 @@
+"""Simple data quality checks for ETL outputs."""
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+from pyspark.sql import DataFrame, functions as F
+
+__all__ = ["row_count_matches", "missing_counts", "run_checks"]
+
+
+def row_count_matches(df: DataFrame, sample_csv: str) -> bool:
+    """Compare row count against a reference CSV file.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to evaluate.
+    sample_csv:
+        Path to reference OMOP CSV (e.g. Synthea output).
+
+    Returns
+    -------
+    bool
+        ``True`` if the row counts match.  If the reference file is missing or
+        empty the function returns ``True`` when ``df`` is also empty.
+    """
+    try:
+        sample = pd.read_csv(sample_csv)
+        sample_count = len(sample)
+    except Exception:
+        sample_count = 0
+    return df.count() == sample_count
+
+
+def missing_counts(df: DataFrame) -> Dict[str, int]:
+    """Return the number of null values for each column in ``df``."""
+    return {c: df.filter(F.col(c).isNull()).count() for c in df.columns}
+
+
+def run_checks(df: DataFrame, sample_csv: str) -> Dict[str, object]:
+    """Run basic quality checks returning a summary dictionary."""
+    return {
+        "row_count_match": row_count_matches(df, sample_csv),
+        "missing": missing_counts(df),
+    }

--- a/mapping/fhir_to_omop_person.yaml
+++ b/mapping/fhir_to_omop_person.yaml
@@ -1,0 +1,22 @@
+person_id:
+  source: id
+gender_concept_id:
+  source: gender
+  concept_map:
+    male: 8507
+    female: 8532
+    other: 0
+    unknown: 0
+year_of_birth:
+  source: birthDate
+  transform: year
+month_of_birth:
+  source: birthDate
+  transform: month
+day_of_birth:
+  source: birthDate
+  transform: day
+race_concept_id:
+  default: 0
+ethnicity_concept_id:
+  default: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyspark
+pyyaml
+pandas


### PR DESCRIPTION
## Summary
- add parser for flattening FHIR NDJSON into Spark DataFrames
- support config-driven mapping of Patient data to OMOP PERSON
- provide loader and quality check helpers plus example mapping config

## Testing
- `pytest -q`
- `python - <<'PYTHON'
from pyspark.sql import SparkSession
from fhiromop.parser import flatten
from fhiromop.config import load_mapping
from fhiromop.mapper import map_person

spark = SparkSession.builder.master("local[1]").appName("demo").getOrCreate()
sc = spark.sparkContext

df = spark.read.json(sc.parallelize(['{"id":"1","gender":"female","birthDate":"1980-01-02"}']))
flat_df = flatten(df)
config = load_mapping('mapping/fhir_to_omop_person.yaml')
person_df = map_person(flat_df, config)
person_df.show()
spark.stop()
PYTHON`

------
https://chatgpt.com/codex/tasks/task_e_68bce46164b08331aaa037bff9655e09