### PR TITLE
Implement basic FHIR to OMOP ETL utilities

### DIFF
--- a/fhiromop/__init__.py
+++ b/fhiromop/__init__.py
@@ -1,0 +1,3 @@
+"""Top level package for FHIR to OMOP ETL examples."""
+
+__all__ = ["parser", "mapper", "loader", "config", "qc"]

--- a/fhiromop/config.py
+++ b/fhiromop/config.py
@@ -1,0 +1,65 @@
+"""Configuration helpers for mapping FHIR resources to OMOP tables."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+__all__ = ["FieldMapping", "MappingConfig", "load_mapping"]
+
+
+@dataclass
+class FieldMapping:
+    """Configuration for a single OMOP field."""
+
+    source: str | None = None
+    """Name of the source column in the flattened FHIR DataFrame."""
+
+    transform: str | None = None
+    """Optional transformation applied to the source column (``year``,
+    ``month`` or ``day`` for date columns)."""
+
+    concept_map: Dict[str, int] | None = None
+    """Optional mapping from source string values to OMOP concept identifiers."""
+
+    default: Any | None = None
+    """Default value used when no source column is provided."""
+
+
+@dataclass
+class MappingConfig:
+    """Container for mapping configuration."""
+
+    fields: Dict[str, FieldMapping]
+
+
+def load_mapping(path: str | Path) -> MappingConfig:
+    """Load mapping configuration from a YAML file.
+
+    The YAML file must define a mapping where keys correspond to target OMOP
+    fields and values describe how those fields are constructed.  Minimal
+    validation is performed to ensure each field mapping contains either a
+    ``source`` or ``default`` attribute.
+    """
+    with open(path, "r", encoding="utf8") as f:
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("Mapping config must be a mapping")
+
+    fields: Dict[str, FieldMapping] = {}
+    for target, cfg in raw.items():
+        if not isinstance(cfg, dict):
+            raise ValueError(f"Configuration for '{target}' must be a mapping")
+        if "source" not in cfg and "default" not in cfg:
+            raise ValueError(
+                f"Configuration for '{target}' must have 'source' or 'default'"
+            )
+        fields[target] = FieldMapping(
+            source=cfg.get("source"),
+            transform=cfg.get("transform"),
+            concept_map=cfg.get("concept_map"),
+            default=cfg.get("default"),
+        )
+    return MappingConfig(fields=fields)

--- a/fhiromop/loader.py
+++ b/fhiromop/loader.py
@@ -1,0 +1,17 @@
+"""Functions for writing OMOP formatted data."""
+from __future__ import annotations
+
+from pyspark.sql import DataFrame
+
+__all__ = ["save_person"]
+
+
+def save_person(df: DataFrame, path: str) -> None:
+    """Save a PERSON table DataFrame to a CSV file.
+
+    The implementation collects the data on the driver node and writes a single
+    CSV file.  This is sufficient for demonstration purposes and small sample
+    data sets.  In a production ETL one would typically write directly using
+    Spark's distributed ``DataFrameWriter``.
+    """
+    df.toPandas().to_csv(path, index=False)

--- a/fhiromop/mapper.py
+++ b/fhiromop/mapper.py
@@ -1,0 +1,59 @@
+"""Mapping logic to transform flattened FHIR data to OMOP tables."""
+from __future__ import annotations
+
+from typing import List
+
+from pyspark.sql import DataFrame, functions as F
+
+from .config import FieldMapping, MappingConfig
+
+__all__ = ["map_person"]
+
+
+def _apply_field(df: DataFrame, mapping: FieldMapping) -> F.Column:
+    """Build a Spark column expression for a single field mapping."""
+    if mapping.source is not None:
+        col = F.col(mapping.source)
+        if mapping.transform == "year":
+            col = F.year(F.to_date(col))
+        elif mapping.transform == "month":
+            col = F.month(F.to_date(col))
+        elif mapping.transform == "day":
+            col = F.dayofmonth(F.to_date(col))
+        if mapping.concept_map:
+            from itertools import chain
+
+            mapping_expr = F.create_map(
+                list(
+                    chain(*[(F.lit(k), F.lit(v)) for k, v in mapping.concept_map.items()])
+                )
+            )
+            col = mapping_expr.getItem(col)
+    elif mapping.default is not None:
+        col = F.lit(mapping.default)
+    else:
+        col = F.lit(None)
+    return col
+
+
+def map_person(df: DataFrame, config: MappingConfig) -> DataFrame:
+    """Map flattened FHIR Patient DataFrame into OMOP PERSON format.
+
+    Parameters
+    ----------
+    df:
+        Flattened FHIR Patient DataFrame (output of
+        :func:`fhiromop.parser.read_patient_ndjson`).
+    config:
+        Mapping configuration loaded via :func:`fhiromop.config.load_mapping`.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame containing columns defined in the mapping configuration in the
+        order specified.
+    """
+    cols: List[F.Column] = []
+    for target, field_cfg in config.fields.items():
+        cols.append(_apply_field(df, field_cfg).alias(target))
+    return df.select(*cols)

--- a/fhiromop/parser.py
+++ b/fhiromop/parser.py
@@ -1,0 +1,89 @@
+"""Utility functions for reading and flattening FHIR NDJSON files.
+
+This module contains helpers to load FHIR resources exported by Synthea in
+NDJSON (newline delimited JSON) format and recursively flatten nested
+structures into a flat :class:`pyspark.sql.DataFrame`.
+
+Only a very small subset of the FHIR specification is supported and the
+flattening logic is intentionally simple.  The goal is to provide an easy to
+understand example that can be extended for additional resources.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+__all__ = ["read_patient_ndjson", "flatten"]
+
+
+def read_patient_ndjson(spark: SparkSession, path: str) -> DataFrame:
+    """Read a Synthea FHIR Patient NDJSON file and return a flat DataFrame.
+
+    Parameters
+    ----------
+    spark:
+        Active :class:`~pyspark.sql.SparkSession`.
+    path:
+        Path to the NDJSON file containing Patient resources.
+
+    Returns
+    -------
+    DataFrame
+        A DataFrame where nested structures have been flattened into top level
+        columns using ``_`` as a separator.
+    """
+    df = spark.read.json(path)
+    return flatten(df)
+
+
+def flatten(df: DataFrame) -> DataFrame:
+    """Recursively flatten a DataFrame with nested structures.
+
+    The algorithm iteratively expands ``StructType`` columns into individual
+    columns and explodes arrays of structs.  Arrays of primitive values are
+    converted to comma separated strings.  The function stops once no complex
+    fields remain.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame possibly containing nested columns.
+
+    Returns
+    -------
+    DataFrame
+        A flattened DataFrame with no ``StructType`` or ``ArrayType`` columns.
+    """
+    complex_fields: List[tuple[str, T.DataType]] = [
+        (field.name, field.dataType)
+        for field in df.schema.fields
+        if isinstance(field.dataType, (T.ArrayType, T.StructType))
+    ]
+
+    while complex_fields:
+        col_name, data_type = complex_fields.pop(0)
+        if isinstance(data_type, T.StructType):
+            # Expand struct by adding each field as a top level column
+            expanded = [
+                F.col(f"{col_name}.{name}").alias(f"{col_name}_{name}")
+                for name in data_type.names
+            ]
+            df = df.select("*", *expanded).drop(col_name)
+        elif isinstance(data_type, T.ArrayType):
+            if isinstance(data_type.elementType, T.StructType):
+                # Explode array of structs and continue flattening
+                df = df.withColumn(col_name, F.explode_outer(col_name))
+            else:
+                # Array of primitives -> comma separated string
+                df = df.withColumn(
+                    col_name, F.concat_ws(",", col_name)
+                )
+        complex_fields = [
+            (field.name, field.dataType)
+            for field in df.schema.fields
+            if isinstance(field.dataType, (T.ArrayType, T.StructType))
+        ]
+    return df

--- a/fhiromop/qc.py
+++ b/fhiromop/qc.py
@@ -1,0 +1,46 @@
+"""Simple data quality checks for ETL outputs."""
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+from pyspark.sql import DataFrame, functions as F
+
+__all__ = ["row_count_matches", "missing_counts", "run_checks"]
+
+
+def row_count_matches(df: DataFrame, sample_csv: str) -> bool:
+    """Compare row count against a reference CSV file.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to evaluate.
+    sample_csv:
+        Path to reference OMOP CSV (e.g. Synthea output).
+
+    Returns
+    -------
+    bool
+        ``True`` if the row counts match.  If the reference file is missing or
+        empty the function returns ``True`` when ``df`` is also empty.
+    """
+    try:
+        sample = pd.read_csv(sample_csv)
+        sample_count = len(sample)
+    except Exception:
+        sample_count = 0
+    return df.count() == sample_count
+
+
+def missing_counts(df: DataFrame) -> Dict[str, int]:
+    """Return the number of null values for each column in ``df``."""
+    return {c: df.filter(F.col(c).isNull()).count() for c in df.columns}
+
+
+def run_checks(df: DataFrame, sample_csv: str) -> Dict[str, object]:
+    """Run basic quality checks returning a summary dictionary."""
+    return {
+        "row_count_match": row_count_matches(df, sample_csv),
+        "missing": missing_counts(df),
+    }

--- a/mapping/fhir_to_omop_person.yaml
+++ b/mapping/fhir_to_omop_person.yaml
@@ -1,0 +1,22 @@
+person_id:
+  source: id
+gender_concept_id:
+  source: gender
+  concept_map:
+    male: 8507
+    female: 8532
+    other: 0
+    unknown: 0
+year_of_birth:
+  source: birthDate
+  transform: year
+month_of_birth:
+  source: birthDate
+  transform: month
+day_of_birth:
+  source: birthDate
+  transform: day
+race_concept_id:
+  default: 0
+ethnicity_concept_id:
+  default: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyspark
+pyyaml
+pandas

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import pytest
+from pyspark.sql import SparkSession
+
+# Ensure package root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+@pytest.fixture(scope="session")
+def spark():
+    spark = (
+        SparkSession.builder.master("local[1]")
+        .appName("fhiromop-tests")
+        .getOrCreate()
+    )
+    yield spark
+    spark.stop()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+import pytest
+
+from textwrap import dedent
+
+from fhiromop.config import FieldMapping, load_mapping
+
+
+def test_load_mapping_valid(tmp_path):
+    content = dedent(
+        """
+        person_id:
+          source: id
+        gender_concept_id:
+          default: 0
+        """
+    )
+    path = tmp_path / "cfg.yaml"
+    path.write_text(content)
+    cfg = load_mapping(path)
+    assert "person_id" in cfg.fields
+    assert isinstance(cfg.fields["gender_concept_id"], FieldMapping)
+    assert cfg.fields["gender_concept_id"].default == 0
+
+
+def test_load_mapping_invalid_root(tmp_path):
+    path = tmp_path / "cfg.yaml"
+    path.write_text("- not_a_mapping")
+    with pytest.raises(ValueError):
+        load_mapping(path)
+
+
+def test_load_mapping_requires_source_or_default(tmp_path):
+    path = tmp_path / "cfg.yaml"
+    path.write_text("field: {}")
+    with pytest.raises(ValueError):
+        load_mapping(path)
+
+
+def test_field_mapping_defaults():
+    fm = FieldMapping()
+    assert fm.source is None
+    assert fm.default is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,41 @@
+import json
+
+import pandas as pd
+
+from fhiromop.config import load_mapping
+from fhiromop.loader import save_person
+from fhiromop.mapper import map_person
+from fhiromop.parser import read_patient_ndjson
+from fhiromop.qc import run_checks
+
+
+def test_full_etl_pipeline(tmp_path, spark):
+    # Prepare NDJSON input
+    patient_path = tmp_path / "patients.ndjson"
+    patient_record = {
+        "id": "1",
+        "gender": "female",
+        "birthDate": "1980-01-02",
+    }
+    patient_path.write_text(json.dumps(patient_record))
+
+    # Load mapping configuration
+    mapping = load_mapping("mapping/fhir_to_omop_person.yaml")
+
+    # Parse and map
+    flat = read_patient_ndjson(spark, str(patient_path))
+    person = map_person(flat, mapping)
+
+    # Save output
+    out_csv = tmp_path / "person.csv"
+    save_person(person, str(out_csv))
+
+    # Quality checks against saved file
+    checks = run_checks(person, str(out_csv))
+    assert checks["row_count_match"]
+    assert checks["missing"] == {c: 0 for c in person.columns}
+
+    # Verify file content
+    loaded = pd.read_csv(out_csv)
+    assert len(loaded) == 1
+    assert loaded.loc[0, "gender_concept_id"] == 8532

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from fhiromop.loader import save_person
+
+
+def test_save_person_writes_csv(tmp_path, spark):
+    df = spark.createDataFrame(
+        [("1", 8532, 1980)],
+        "person_id string, gender_concept_id int, year_of_birth int",
+    )
+    path = tmp_path / "person.csv"
+    save_person(df, str(path))
+    assert path.exists()
+    loaded = pd.read_csv(path)
+    assert list(loaded.columns) == ["person_id", "gender_concept_id", "year_of_birth"]
+    assert str(loaded.loc[0, "person_id"]) == "1"
+    assert loaded.loc[0, "gender_concept_id"] == 8532
+    assert loaded.loc[0, "year_of_birth"] == 1980
+
+
+def test_save_person_empty_dataframe(tmp_path, spark):
+    df = spark.createDataFrame([], "person_id string, gender_concept_id int")
+    path = tmp_path / "empty.csv"
+    save_person(df, str(path))
+    loaded = pd.read_csv(path)
+    assert loaded.empty
+    assert list(loaded.columns) == ["person_id", "gender_concept_id"]

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,57 @@
+import json
+
+import pytest
+from pyspark.sql.utils import AnalysisException
+
+from fhiromop.config import load_mapping
+from fhiromop.mapper import map_person
+from fhiromop.parser import flatten
+
+
+@pytest.fixture(scope="module")
+def mapping_path(tmp_path_factory):
+    # Use repository mapping file content for tests
+    from pathlib import Path
+    repo_mapping = Path("mapping/fhir_to_omop_person.yaml").read_text()
+    path = tmp_path_factory.mktemp("mapping") / "map.yaml"
+    path.write_text(repo_mapping)
+    return str(path)
+
+
+def test_map_person_transforms_and_defaults(spark, mapping_path):
+    df = spark.read.json(
+        spark.sparkContext.parallelize(
+            ['{"id":"1","gender":"female","birthDate":"1980-01-02"}']
+        )
+    )
+    flat = flatten(df)
+    config = load_mapping(mapping_path)
+    person = map_person(flat, config)
+    row = person.collect()[0]
+    assert row.person_id == "1"
+    assert row.gender_concept_id == 8532
+    assert row.year_of_birth == 1980
+    assert row.month_of_birth == 1
+    assert row.day_of_birth == 2
+    assert row.race_concept_id == 0
+
+
+def test_map_person_concept_map_unknown(spark, mapping_path):
+    df = spark.read.json(
+        spark.sparkContext.parallelize(
+            ['{"id":"1","gender":"invalid","birthDate":"1980-01-02"}']
+        )
+    )
+    flat = flatten(df)
+    config = load_mapping(mapping_path)
+    person = map_person(flat, config)
+    row = person.collect()[0]
+    assert row.gender_concept_id is None
+
+
+def test_map_person_missing_column_raises(spark, mapping_path):
+    df = spark.read.json(spark.sparkContext.parallelize(['{"id":"1"}']))
+    flat = flatten(df)
+    config = load_mapping(mapping_path)
+    with pytest.raises(AnalysisException):
+        map_person(flat, config).collect()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,1 +1,55 @@
-# Test FHIR flattening
+import json
+
+from fhiromop.parser import flatten, read_patient_ndjson
+
+
+def test_flatten_handles_structs_and_arrays(spark):
+    data = [
+        {
+            "id": "1",
+            "name": [{"given": ["Alice", "B"], "family": "Smith"}],
+            "address": {"line": ["123 St", "Apt 4"], "city": "Town"},
+        }
+    ]
+    df = spark.read.json(spark.sparkContext.parallelize([json.dumps(data[0])]))
+    flat = flatten(df)
+    row = flat.collect()[0]
+    assert row.id == "1"
+    assert row.name_given == "Alice,B"
+    assert row.name_family == "Smith"
+    assert row.address_line == "123 St,Apt 4"
+    assert row.address_city == "Town"
+
+
+def test_flatten_array_of_structs_creates_multiple_rows(spark):
+    data = {
+        "id": "1",
+        "name": [
+            {"given": ["Alice"], "family": "Smith"},
+            {"given": ["Ally"], "family": "Jones"},
+        ],
+    }
+    df = spark.read.json(spark.sparkContext.parallelize([json.dumps(data)]))
+    flat = flatten(df)
+    assert flat.count() == 2
+    families = {r.name_family for r in flat.collect()}
+    assert families == {"Smith", "Jones"}
+
+
+def test_read_patient_ndjson(tmp_path, spark):
+    path = tmp_path / "patients.ndjson"
+    content = """{"id": "1", "gender": "female"}
+{"id": "2", "gender": "male"}
+"""
+    path.write_text(content)
+    df = read_patient_ndjson(spark, str(path))
+    assert set(df.columns) == {"id", "gender"}
+    assert df.count() == 2
+
+
+def test_read_patient_ndjson_empty(tmp_path, spark):
+    path = tmp_path / "empty.ndjson"
+    path.write_text("")
+    df = read_patient_ndjson(spark, str(path))
+    assert df.count() == 0
+    assert df.columns == []

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from fhiromop.qc import missing_counts, row_count_matches, run_checks
+
+
+def test_row_count_matches(tmp_path, spark):
+    df = spark.createDataFrame([(1,), (2,)], ["id"])
+    ref = tmp_path / "ref.csv"
+    pd.DataFrame({"id": [1, 2]}).to_csv(ref, index=False)
+    assert row_count_matches(df, str(ref))
+    pd.DataFrame({"id": [1]}).to_csv(ref, index=False)
+    assert not row_count_matches(df, str(ref))
+
+
+def test_row_count_matches_missing_file(tmp_path, spark):
+    df = spark.createDataFrame([], "id int")
+    missing_path = tmp_path / "missing.csv"
+    assert row_count_matches(df, str(missing_path))
+    df_non_empty = spark.createDataFrame([(1,)], ["id"])
+    assert not row_count_matches(df_non_empty, str(missing_path))
+
+
+def test_missing_counts(spark):
+    df = spark.createDataFrame([(1, None), (2, "x")], ["a", "b"])
+    counts = missing_counts(df)
+    assert counts["a"] == 0
+    assert counts["b"] == 1
+
+
+def test_run_checks(tmp_path, spark):
+    df = spark.createDataFrame([(1, None)], "a int, b string")
+    ref = tmp_path / "ref.csv"
+    pd.DataFrame({"a": [1]}).to_csv(ref, index=False)
+    result = run_checks(df, str(ref))
+    assert result["row_count_match"]
+    assert result["missing"]["b"] == 1


### PR DESCRIPTION
## Summary
- add parser for flattening FHIR NDJSON into Spark DataFrames
- support config-driven mapping of Patient data to OMOP PERSON
- provide loader and quality check helpers plus example mapping config
- introduce comprehensive unit tests across parser, mapper, loader, config, qc, and full pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce46164b08331aaa037bff9655e09